### PR TITLE
fix: visual bug fix for zen, by referencing the link tag to public folder

### DIFF
--- a/themes/zen/index.html
+++ b/themes/zen/index.html
@@ -20,7 +20,7 @@
       href="/opensearch.xml"
     />
     <title>zen</title>
-    <link rel="stylesheet" href="/theme/style.css?v=__APP_VERSION__" />
+    <link rel="stylesheet" href="/public/style.css?v=__APP_VERSION__" />
     <script>
       (function () {
         var t = localStorage.getItem("theme");

--- a/themes/zen/search.html
+++ b/themes/zen/search.html
@@ -32,7 +32,7 @@
         }
       })();
     </script>
-    <link rel="stylesheet" href="/theme/style.css?v=__APP_VERSION__" />
+    <link rel="stylesheet" href="/public/style.css?v=__APP_VERSION__" />
     __THEME_CSS__ __PLUGIN_ASSETS__
   </head>
   <body class="has-results">


### PR DESCRIPTION
This is push for fixing an a bug, where the link tag referenced to an unknown file ` <link rel="stylesheet" href="/theme/style.css?v=__APP_VERSION__" />`, 

I just change it from `/theme/style.css` into `/public/style.css` making it correctly reference the style sheet.

Before:
<img width="1827" height="934" alt="image" src="https://github.com/user-attachments/assets/337b846f-38ee-4709-8425-e31bd8ae284d" />


After:
<img width="1829" height="924" alt="image" src="https://github.com/user-attachments/assets/5ce4ca42-a3eb-40be-8b47-e60b0132dd8d" />
