### PR TITLE
Fixed the "search-history" plugin

### DIFF
--- a/plugins/search-history/script.js
+++ b/plugins/search-history/script.js
@@ -75,7 +75,7 @@ function fetchAndShowHistory(input, dropdown, performSearch) {
     .catch(() => {});
 }
 
-function appendHistory(entry, onNavigate = false) {
+function appendHistory(entry, onNavigate = true) {
   const q = (entry || "").trim();
   if (!q || q === "!history" || q.startsWith("!history ")) return;
   const payload = JSON.stringify({ entry: q });
@@ -126,8 +126,8 @@ function initSearchHistory() {
   }
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initSearchHistory);
-} else {
-  initSearchHistory();
+document.onreadystatechange = () => {
+  if (document.readyState === "complete"){
+    initSearchHistory()
+  }
 }

--- a/plugins/search-history/script.js
+++ b/plugins/search-history/script.js
@@ -75,7 +75,7 @@ function fetchAndShowHistory(input, dropdown, performSearch) {
     .catch(() => {});
 }
 
-function appendHistory(entry, onNavigate = true) {
+function appendHistory(entry, onNavigate = false) {
   const q = (entry || "").trim();
   if (!q || q === "!history" || q.startsWith("!history ")) return;
   const payload = JSON.stringify({ entry: q });


### PR DESCRIPTION
From what i can see, the search history plugin does not work.
Might just be on my setup, but i tried looking further into it.
From what i can see, the plugin tries to set a bunch of event listeners, before the DOM is fully rendered, which results in it not finding the "search-input" elements.
Im not entirely sure why this happens (maybe something to do with the plugin system loading in async)
But a simple change to using the `readyStateChange` and only initializing the search history when the `readyState` is `complete` seems to work.