### PR TITLE
Auto-updating camoufox container

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Fetches pages through a self-hosted CloakBrowser service (stealth Chromium). Pat
 
 ### Camoufox
 
-Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See homelab/camoufox for the Docker service.
+Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See Korosys/camoufox-degoog for the Docker service.
 
 <details>
 <summary>Screenshot</summary>

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Fetches pages through a self-hosted CloakBrowser service (stealth Chromium). Pat
 
 ### Camoufox
 
-Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See Korosys/camoufox-degoog for the Docker service.
+Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See [Korosys/camoufox-degoog](https://github.com/Korosys/camoufox-degoog) for the Docker service.
 
 <details>
 <summary>Screenshot</summary>

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     {
       "path": "transports/camoufox",
       "name": "Camoufox",
-      "description": "Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See homelab/camoufox for the Docker service.",
+      "description": "Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See Korosys/camoufox-degoog for the Docker service.",
       "version": "1.0.1"
     },
     {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
       "path": "transports/camoufox",
       "name": "Camoufox",
       "description": "Fetches pages through a self-hosted Camoufox service (stealth Firefox). Patches bot-detection signals at the C++ level, bypassing Google and Cloudflare. See Korosys/camoufox-degoog for the Docker service.",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "path": "transports/degoog-fplay",


### PR DESCRIPTION
I made a self updating docker container by following the instructions provided in the plugin details here https://degoog-org.github.io/community-extensions/#repo=https%3A%2F%2Fgithub.com%2Fdegoog-org%2Fofficial-extensions&ext=transports%2Fcamoufox

I had to add a line to the dockerfile because I was getting errors, and it should automatically update with camoufox. you can look at it here:

https://github.com/Korosys/camoufox-degoog