### PR TITLE
replace the `focusin` trigger with a "left-click-only" trigger

### DIFF
--- a/plugins/search-history/script.js
+++ b/plugins/search-history/script.js
@@ -85,10 +85,10 @@ const appendHistory = (entry) => {
     keepalive: true,
   }).catch(() => {});
 }
-// Replace the previous focusin trigger with mousedown so the search history dropdown opens only on left click and does not overlap FreshRSS feeds on page load.
+
 function initSearchHistory() {
   document.addEventListener('mousedown', (e) => {
-    if (e.button !== 0) return; // Only on left Clik
+    if (e.button !== 0) return;
 
     const target = e.target;
     if (!(target instanceof HTMLElement)) return;

--- a/plugins/search-history/script.js
+++ b/plugins/search-history/script.js
@@ -85,18 +85,25 @@ const appendHistory = (entry) => {
     keepalive: true,
   }).catch(() => {});
 }
-
+// Replace the previous focusin trigger with mousedown so the search history dropdown opens only on left click and does not overlap FreshRSS feeds on page load.
 function initSearchHistory() {
-  document.addEventListener("focusin", (e) => {
+  document.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return; // Only on left Clik
+
     const target = e.target;
     if (!(target instanceof HTMLElement)) return;
+
+    const input = target.closest('#search-input, #results-search-input');
+    if (!(input instanceof HTMLInputElement)) return;
+
     const performSearch = window.performSearch;
-    if (target.id === "search-input") {
-      const dropdown = document.getElementById("ac-dropdown-home");
-      if (dropdown) fetchAndShowHistory(target, dropdown, performSearch);
-    } else if (target.id === "results-search-input") {
-      const dropdown = document.getElementById("ac-dropdown-results");
-      if (dropdown) fetchAndShowHistory(target, dropdown, performSearch);
+
+    if (input.id === 'search-input') {
+      const dropdown = document.getElementById('ac-dropdown-home');
+      if (dropdown) fetchAndShowHistory(input, dropdown, performSearch);
+    } else if (input.id === 'results-search-input') {
+      const dropdown = document.getElementById('ac-dropdown-results');
+      if (dropdown) fetchAndShowHistory(input, dropdown, performSearch);
     }
   });
 


### PR DESCRIPTION
The current behavior can open the history panel as soon as the page loads if the search field is auto-focused.  
Opening only on left click makes the interaction explicit and avoids unwanted dropdown display.

Changes
- replace the `focusin` trigger with a left-click-only trigger
- keep the existing history rendering logic unchanged

Testing
- loaded the home page: history no longer opens automatically
- left-click in the search field: history opens
- keyboard focus alone: history does not open
- existing search history storage behavior unchanged