### PR TITLE
fix(brave-news): update selectors to match new HTML structure

### DIFF
--- a/engines/brave-news/index.js
+++ b/engines/brave-news/index.js
@@ -54,7 +54,7 @@ export default class BraveNewsEngine {
     const $ = cheerio.load(html);
     const results = [];
 
-    $("a[target='_self'][href^='http']").each((_, el) => {
+    $("div.snippet[data-type='news'], div[data-type='news']").each((_, el) => {
       const $el = $(el);
       const href = $el.attr("href") ?? "";
       if (!href) return;

--- a/engines/brave-news/index.js
+++ b/engines/brave-news/index.js
@@ -34,8 +34,8 @@ export default class BraveNewsEngine {
     }
     const lang = context?.lang;
     const cookie = lang && lang !== "en"
-      ? `safesearch=${this.safeSearch}; useLocation=0; country=${lang}; ui_lang=${lang}-${lang}`
-      : `safesearch=${this.safeSearch}; useLocation=0; country=us; ui_lang=en-us`;
+        ? `safesearch=${this.safeSearch}; useLocation=0; country=${lang}; ui_lang=${lang}-${lang}`
+        : `safesearch=${this.safeSearch}; useLocation=0; country=us; ui_lang=en-us`;
     const url = `https://search.brave.com/news?${new URLSearchParams(params)}`;
     const doFetch = context?.fetch ?? fetch;
     const res = await doFetch(url, {
@@ -56,14 +56,11 @@ export default class BraveNewsEngine {
 
     $("div.snippet[data-type='news'], div[data-type='news']").each((_, el) => {
       const $el = $(el);
-      const href = $el.attr("href") ?? "";
-      if (!href) return;
-      try {
-        const parsed = new URL(href, "https://search.brave.com");
-        if (parsed.hostname === "search.brave.com") return;
-      } catch { return; }
+      const linkEl = $el.find("a[href^='http']").first();
+      const href = linkEl.attr("href") ?? "";
       const title = $el.find("div.title").text().trim() || $el.text().trim();
       const snippet = $el.find("div.description").text().trim() || "";
+      const source = $el.find(".site-name-content > span:first-child").text().trim() || "";
       const thumbnail = context?.extractImageUrl?.($el, "https://search.brave.com", [
         ".snippet-thumbnail-wrapper .thumbnail img",
         ".result-thumbnail-wrapper .thumbnail img",
@@ -72,7 +69,7 @@ export default class BraveNewsEngine {
       ]) ?? "";
       if (title) {
         results.push({
-          title, url: href, snippet, source: this.name,
+          title, url: href, snippet, source: source ?? this.name,
           ...(thumbnail ? { thumbnail } : {}),
         });
       }

--- a/engines/brave-news/index.js
+++ b/engines/brave-news/index.js
@@ -54,7 +54,7 @@ export default class BraveNewsEngine {
     const $ = cheerio.load(html);
     const results = [];
 
-    $("a.l1.svelte-md19lk, a[href^='http'][target='_self'][class*='svelte']").each((_, el) => {
+    $("a[target='_self'][href^='http']").each((_, el) => {
       const $el = $(el);
       const href = $el.attr("href") ?? "";
       if (!href) return;
@@ -62,12 +62,8 @@ export default class BraveNewsEngine {
         const parsed = new URL(href, "https://search.brave.com");
         if (parsed.hostname === "search.brave.com") return;
       } catch { return; }
-      const title = $el.find("div.title.svelte-md19lk").text().trim()
-        || $el.find(".title").text().trim()
-        || $el.text().trim();
-      const snippet = $el.find("div.description.t-primary").text().trim()
-        || $el.find(".content .description").text().trim()
-        || "";
+      const title = $el.find("div.title").text().trim() || $el.text().trim();
+      const snippet = $el.find("div.description").text().trim() || "";
       const thumbnail = context?.extractImageUrl?.($el, "https://search.brave.com", [
         ".snippet-thumbnail-wrapper .thumbnail img",
         ".result-thumbnail-wrapper .thumbnail img",

--- a/engines/brave-news/index.js
+++ b/engines/brave-news/index.js
@@ -54,18 +54,20 @@ export default class BraveNewsEngine {
     const $ = cheerio.load(html);
     const results = [];
 
-    $("div.snippet[data-type='news'], div[data-type='news']").each((_, el) => {
+    $("a.l1.svelte-md19lk, a[href^='http'][target='_self'][class*='svelte']").each((_, el) => {
       const $el = $(el);
-      const linkEl = $el.find("a[href^='http']").first();
-      const href = linkEl.attr("href") ?? "";
+      const href = $el.attr("href") ?? "";
       if (!href) return;
       try {
         const parsed = new URL(href, "https://search.brave.com");
         if (parsed.hostname === "search.brave.com") return;
       } catch { return; }
-      const title = $el.find("span.snippet-title, .snippet-title, div[class*='snippet-title']").text().trim()
-        || linkEl.text().trim();
-      const snippet = $el.find(".snippet-description, .snippet-content, div[class*='snippet-description']").text().trim();
+      const title = $el.find("div.title.svelte-md19lk").text().trim()
+        || $el.find(".title").text().trim()
+        || $el.text().trim();
+      const snippet = $el.find("div.description.t-primary").text().trim()
+        || $el.find(".content .description").text().trim()
+        || "";
       const thumbnail = context?.extractImageUrl?.($el, "https://search.brave.com", [
         ".snippet-thumbnail-wrapper .thumbnail img",
         ".result-thumbnail-wrapper .thumbnail img",

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
       "path": "engines/brave-news",
       "name": "Brave News",
       "description": "Brave news search.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minDegoogVersion": "0.19.0",
       "legacyIds": [
         "brave-news",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and collection of Brave News search results for more reliable parsing.
  * Updated link, title, and snippet extraction to use the current result element, improving accuracy of displayed information.
  * Kept the existing filtering behavior to avoid showing internal Brave search links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->