### PR TITLE
fix(4play-status): accept settings-token cookie for admin auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "path": "plugins/4play-status",
       "name": "4play status",
       "description": "Admin-gated !4play bang showing live 4play transport status: warmed sessions, blocked origins, containers, and clear controls.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "command",
       "minDegoogVersion": "0.23.0"
     },

--- a/plugins/4play-status/index.js
+++ b/plugins/4play-status/index.js
@@ -27,15 +27,24 @@ const apiBaseFor = (reqUrl) => {
   return `${url.origin}${base}`;
 };
 
-const tokenFrom = (req) => req.headers.get("x-settings-token") || "";
+const SETTINGS_TOKEN_COOKIE = "settings-token";
+
+const tokenFrom = (req) => {
+  const fromHeader = req.headers.get("x-settings-token");
+  if (fromHeader) return fromHeader;
+
+  const raw = req.headers.get("cookie");
+  if (!raw) return "";
+
+  const match = raw
+    .split(";")
+    .find((part) => part.trim().startsWith(`${SETTINGS_TOKEN_COOKIE}=`));
+  return match?.split("=")[1]?.trim() || "";
+};
 
 const authHeaders = (req) => {
-  const headers = {};
   const token = tokenFrom(req);
-  const cookie = req.headers.get("cookie") || "";
-  if (token) headers["x-settings-token"] = token;
-  if (cookie) headers.cookie = cookie;
-  return headers;
+  return token ? { "x-settings-token": token } : {};
 };
 
 const gandalfSaysYes = async (req) => {

--- a/plugins/4play-status/script.js
+++ b/plugins/4play-status/script.js
@@ -27,6 +27,13 @@
     return token ? { "x-settings-token": token } : {};
   };
 
+  const authFetch = (url, init = {}) =>
+    fetch(url, {
+      credentials: "same-origin",
+      ...init,
+      headers: { ...authHeaders(), ...(init.headers || {}) },
+    });
+
   const initCard = (root) => {
     const body = root.querySelector("[data-body]");
     const connBadge = root.querySelector("[data-conn]");
@@ -237,7 +244,7 @@
 
     const fetchStatus = async () => {
       try {
-        const res = await fetch(`${API_BASE}/status`, { headers: authHeaders() });
+        const res = await authFetch(`${API_BASE}/status`);
         if (res.status === 401) {
           renderLocked();
           return false;
@@ -256,9 +263,9 @@
 
     const yeetSessions = async (scope, key) => {
       try {
-        const res = await fetch(`${API_BASE}/clear`, {
+        const res = await authFetch(`${API_BASE}/clear`, {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...authHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(key ? { scope, key } : { scope }),
         });
         if (!res.ok) throw new Error(`status ${res.status}`);
@@ -275,10 +282,7 @@
     const wakeTransport = async () => {
       setConn("waking", "muted");
       try {
-        const res = await fetch(`${API_BASE}/ping`, {
-          method: "POST",
-          headers: authHeaders(),
-        });
+        const res = await authFetch(`${API_BASE}/ping`, { method: "POST" });
         const data = await res.json().catch(() => ({}));
         if (!res.ok) throw new Error(data?.error || `status ${res.status}`);
         console.warn(


### PR DESCRIPTION
## Summary

Fixes admin-gated `!4play` showing **"Log into the admin panel to unlock the 4play status view"** when the user is already logged into Settings/Admin from another tab.

Degoog issues **one** session token on login, carried two ways:

- HttpOnly cookie **`settings-token`** (all same-origin tabs; JS cannot read it)
- **`sessionStorage`** key **`degoog-settings-token`** (that tab only), sent as **`x-settings-token`** header

The plugin only checked `sessionStorage` / the header. Search tabs often have the cookie but not `sessionStorage`, so auth failed with 401 even while Settings worked.

This matches degoog core's `canBalrogPass()` pattern in `settings-auth.ts` (header first, then `settings-token` cookie). **No degoog core changes.**

## Changes

### `plugins/4play-status/index.js`
- `tokenFrom(req)` — read `x-settings-token` header, else parse `settings-token` from the incoming `Cookie` header on plugin routes.
- `authHeaders(req)` — forward extracted token as `x-settings-token` on internal calls to `/api/settings/auth` and `/api/extensions` (replaces forwarding the raw `Cookie` header).

### `plugins/4play-status/script.js`
- `authFetch()` — `fetch` with `credentials: "same-origin"` so the HttpOnly cookie is sent to `/api/plugin/...` routes from search tabs.
- `/status`, `/clear`, `/ping` use `authFetch()`.

### `package.json`
- Bump 4play-status `1.0.0` → `1.0.1`.

## Test plan

- [ ] Log into Settings/Admin in tab A; run `!4play` in tab B → status dashboard loads (not locked)
- [ ] Logged out → lock card still shown
- [ ] Clear all / per-session clear works when authenticated
- [ ] Wake (`/ping`) works when authenticated
- [ ] Same-tab Settings login still works (header path unchanged)