### PR TITLE
fix(4play-status): accept settings-token cookie for admin auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "path": "plugins/4play-status",
       "name": "4play status",
       "description": "Admin-gated !4play bang showing live 4play transport status: warmed sessions, blocked origins, containers, and clear controls.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "command",
       "minDegoogVersion": "0.23.0"
     },

--- a/plugins/4play-status/index.js
+++ b/plugins/4play-status/index.js
@@ -27,15 +27,24 @@ const apiBaseFor = (reqUrl) => {
   return `${url.origin}${base}`;
 };
 
-const tokenFrom = (req) => req.headers.get("x-settings-token") || "";
+const SETTINGS_TOKEN_COOKIE = "settings-token";
+
+const tokenFrom = (req) => {
+  const fromHeader = req.headers.get("x-settings-token");
+  if (fromHeader) return fromHeader;
+
+  const raw = req.headers.get("cookie");
+  if (!raw) return "";
+
+  const match = raw
+    .split(";")
+    .find((part) => part.trim().startsWith(`${SETTINGS_TOKEN_COOKIE}=`));
+  return match?.split("=")[1]?.trim() || "";
+};
 
 const authHeaders = (req) => {
-  const headers = {};
   const token = tokenFrom(req);
-  const cookie = req.headers.get("cookie") || "";
-  if (token) headers["x-settings-token"] = token;
-  if (cookie) headers.cookie = cookie;
-  return headers;
+  return token ? { "x-settings-token": token } : {};
 };
 
 const gandalfSaysYes = async (req) => {

--- a/plugins/4play-status/script.js
+++ b/plugins/4play-status/script.js
@@ -27,6 +27,13 @@
     return token ? { "x-settings-token": token } : {};
   };
 
+  const authFetch = (url, init = {}) =>
+    fetch(url, {
+      credentials: "same-origin",
+      ...init,
+      headers: { ...authHeaders(), ...(init.headers || {}) },
+    });
+
   const initCard = (root) => {
     const body = root.querySelector("[data-body]");
     const connBadge = root.querySelector("[data-conn]");
@@ -237,7 +244,7 @@
 
     const fetchStatus = async () => {
       try {
-        const res = await fetch(`${API_BASE}/status`, { headers: authHeaders() });
+        const res = await authFetch(`${API_BASE}/status`);
         if (res.status === 401) {
           renderLocked();
           return false;
@@ -256,9 +263,9 @@
 
     const yeetSessions = async (scope, key) => {
       try {
-        const res = await fetch(`${API_BASE}/clear`, {
+        const res = await authFetch(`${API_BASE}/clear`, {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...authHeaders() },
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(key ? { scope, key } : { scope }),
         });
         if (!res.ok) throw new Error(`status ${res.status}`);
@@ -275,10 +282,7 @@
     const wakeTransport = async () => {
       setConn("waking", "muted");
       try {
-        const res = await fetch(`${API_BASE}/ping`, {
-          method: "POST",
-          headers: authHeaders(),
-        });
+        const res = await authFetch(`${API_BASE}/ping`, { method: "POST" });
         const data = await res.json().catch(() => ({}));
         if (!res.ok) throw new Error(data?.error || `status ${res.status}`);
         console.warn(


### PR DESCRIPTION
4play status showed the admin lock screen even when you were logged into Settings in another tab.

Login sets a `settings-token` HttpOnly cookie and `degoog-settings-token` in sessionStorage. The plugin only used sessionStorage / x-settings-token, so search tabs often had no token.
- index.js: read settings-token from Cookie on plugin routes (same as canBalrogPass)
- script.js: credentials: "same-origin" on status/clear/ping fetches
- bump - 1.0.0 → 1.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings authentication handling so requests can use either the current header or a saved cookie, helping avoid unexpected sign-in issues.
  * Updated status and action requests to consistently include the right authentication details, reducing failed requests.

* **Chores**
  * Bumped the `4play-status` plugin version to `1.0.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->