### PR TITLE
github-slot: restore visible horizontal scrollbar on repo/user grid

### DIFF
--- a/plugins/github-slot/style.css
+++ b/plugins/github-slot/style.css
@@ -37,6 +37,14 @@
   min-width: 0;
 }
 
+.gh-slot-grid::-webkit-scrollbar {
+  /* The global theme rule (src/styles/style.scss) only sets `width`, which
+     affects vertical scrollbars. Set the height here so the horizontal bar
+     of this grid matches (0.5rem). Ideally this moves into the theme so all
+     horizontal scrollbars are consistent site-wide. */
+  height: 0.5rem;
+}
+
 .gh-slot-grid::-webkit-scrollbar-track {
   background: var(--bg-hover);
   border-radius: 3px;

--- a/plugins/github-slot/style.css
+++ b/plugins/github-slot/style.css
@@ -37,10 +37,6 @@
   min-width: 0;
 }
 
-.gh-slot-grid::-webkit-scrollbar {
-  display: none;
-}
-
 .gh-slot-grid::-webkit-scrollbar-track {
   background: var(--bg-hover);
   border-radius: 3px;


### PR DESCRIPTION
## Problem

`.gh-slot-grid` is **intentionally** a horizontally scrollable row of fixed-width cards:

```css
.gh-slot-grid {
  display: flex;
  flex-wrap: nowrap;
  overflow-x: auto;
  overflow-y: hidden;
  ...
}
```

But the rule

```css
.gh-slot-grid::-webkit-scrollbar {
  display: none;
}
```

hid the scrollbar completely. With many repos/users listed, there was no visible scroll affordance and sideways scrolling was effectively impossible (no draggable handle). Removing the rule restores the styled scrollbar.

Notably, the file already contains `::-webkit-scrollbar-track` and `::-webkit-scrollbar-thumb` styling right below the hidden rule — a visible, themed scrollbar is clearly the intended design, so `display: none` looks like a leftover.

## Fix

Remove the `::-webkit-scrollbar { display: none; }` rule only. The existing track/thumb styles now take effect and the grid scrolls visibly.

## Notes

- No `scrollbar-width`/`scrollbar-color` is set, so Firefox uses its default visible scrollbar — consistent behavior.
- Verified locally by the reporter: removing the rule restored sideways scrolling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made the horizontal scrollbar visible for the GitHub slot grid.
  * Set the scrollbar height to 0.5rem for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->